### PR TITLE
Feature/#12 docker 및 docker hub를 통한 배포 방식으로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:11-jdk
+
+ADD ./build/libs/*.jar rqs.jar
+
+CMD ["java", "-jar", "-Duser.timezone=Asia/Seoul", "rqs.jar"]


### PR DESCRIPTION
docker 및 docker hub를 통한 배포 방식으로 변경

### 진행
- docker를 통한 배포방식으로 변경
- 기존 MySQL 및 Redis는 도커를 통해 사용 -> Google Cloud의 SQL 제품 및 로컬 Redis 사용으로 변경
  - App (Docker)에서 Redis 연결은 Container의 network 속성에 host를 주어 로컬 네트워크 통신 모드로 설정
- Docker Hub를 통한 Private Repository를 생성하여 빌드 배포

### Flow

1. 로컬 빌드
	1. 추후 github action을 통해 테스트 - 빌드 - 푸시 진행  
2. Docker Hub로 Push
3. 서버에서 이미지 Pull And Run