### PR TITLE
Feature/#39 ATK와 RTK의 혼용 문제 해결

### DIFF
--- a/src/main/java/com/example/rqs/api/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/rqs/api/jwt/JwtAuthenticationFilter.java
@@ -29,8 +29,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String authorization = request.getHeader("Authorization");
         if (!Objects.isNull(authorization)) {
             String atk = authorization.substring(7);
+            String requestURI = request.getRequestURI();
             try {
                 Subject subject = jwtProvider.getSubject(atk);
+                if (subject.getType().equals("RTK") && !requestURI.equals("/api/v1/member/reissue")) {
+                    throw new JwtException("토큰을 확인하세요.");
+                }
                 UserDetails userDetails = memberDetailsService.loadUserByUsername(subject.getEmail());
                 Authentication token = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(token);

--- a/src/main/java/com/example/rqs/api/jwt/JwtProvider.java
+++ b/src/main/java/com/example/rqs/api/jwt/JwtProvider.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.jsonwebtoken.JwtException;
 
 public interface JwtProvider {
-    TokenResponse createTokenList(MemberDto memberDto);
+    TokenResponse createTokensByLogin(MemberDto memberDto);
 
     String reissueAtk(MemberDto memberDto);
     Subject getSubject(String atk) throws JwtException, JsonProcessingException;

--- a/src/main/java/com/example/rqs/api/jwt/JwtProviderImpl.java
+++ b/src/main/java/com/example/rqs/api/jwt/JwtProviderImpl.java
@@ -45,19 +45,16 @@ public class JwtProviderImpl implements JwtProvider {
     }
 
     @Override
-    public TokenResponse createTokenList(MemberDto memberDto) {
+    public TokenResponse createTokensByLogin(MemberDto memberDto) {
+        Subject atkSubject = Subject.atk(memberDto);
+        Subject rtkSubject = Subject.rtk(memberDto);
         try {
-            Subject subject = new Subject(
-                    memberDto.getMemberId(),
-                    memberDto.getEmail(),
-                    memberDto.getNickname(),
-                    memberDto.getRole());
-            String atk = this.createToken(subject, atkLive);
-            String rtk = this.createToken(subject, rtkLive);
+            String atk = this.createToken(atkSubject, atkLive);
+            String rtk = this.createToken(rtkSubject, rtkLive);
             redisDao.setValues(memberDto.getEmail(), rtk, Duration.ofMillis(rtkLive));
             return TokenResponse.of(atk, rtk);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException(e); // Todo: CustomException
         }
     }
 
@@ -65,7 +62,7 @@ public class JwtProviderImpl implements JwtProvider {
     public String reissueAtk(MemberDto memberDto) {
         String rtkInRedis = redisDao.getValues(memberDto.getEmail());
         if (Objects.isNull(rtkInRedis)) throw new ForbiddenException("인증 정보가 만료되었습니다.");
-        TokenResponse tokenList = this.createTokenList(memberDto);
+        TokenResponse tokenList = this.createTokensByLogin(memberDto);
         return tokenList.getAtk();
     }
 

--- a/src/main/java/com/example/rqs/api/jwt/JwtProviderImpl.java
+++ b/src/main/java/com/example/rqs/api/jwt/JwtProviderImpl.java
@@ -61,9 +61,13 @@ public class JwtProviderImpl implements JwtProvider {
     @Override
     public String reissueAtk(MemberDto memberDto) {
         String rtkInRedis = redisDao.getValues(memberDto.getEmail());
+        Subject atkSubject = Subject.atk(memberDto);
         if (Objects.isNull(rtkInRedis)) throw new ForbiddenException("인증 정보가 만료되었습니다.");
-        TokenResponse tokenList = this.createTokensByLogin(memberDto);
-        return tokenList.getAtk();
+        try {
+            return this.createToken(atkSubject, atkLive);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e); // Todo: CustomException
+        }
     }
 
     @Override

--- a/src/main/java/com/example/rqs/api/jwt/Subject.java
+++ b/src/main/java/com/example/rqs/api/jwt/Subject.java
@@ -1,13 +1,12 @@
 package com.example.rqs.api.jwt;
 
+import com.example.rqs.core.member.service.dtos.MemberDto;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Subject {
 
     private Long memberId;
@@ -17,4 +16,25 @@ public class Subject {
     private String nickname;
 
     private String role;
+
+    private String type;
+
+    public static Subject atk(MemberDto memberDto) {
+        return new Subject(
+                memberDto.getMemberId(),
+                memberDto.getEmail(),
+                memberDto.getNickname(),
+                memberDto.getRole(),
+                "ATK");
+    }
+
+    public static Subject rtk(MemberDto memberDto) {
+        return new Subject(
+                memberDto.getMemberId(),
+                memberDto.getEmail(),
+                memberDto.getNickname(),
+                memberDto.getRole(),
+                "RTK");
+    }
+
 }

--- a/src/main/java/com/example/rqs/api/jwt/Subject.java
+++ b/src/main/java/com/example/rqs/api/jwt/Subject.java
@@ -4,9 +4,11 @@ import com.example.rqs.core.member.service.dtos.MemberDto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Subject {
 
     private Long memberId;

--- a/src/main/java/com/example/rqs/api/member/MemberController.java
+++ b/src/main/java/com/example/rqs/api/member/MemberController.java
@@ -43,7 +43,7 @@ public class MemberController {
     @PostMapping("/login")
     public ResponseEntity<TokenResponse> login(@RequestBody LoginDto loginDto) {
         MemberDto memberDto = memberService.login(loginDto);
-        TokenResponse tokenList = jwtProvider.createTokenList(memberDto);
+        TokenResponse tokenList = jwtProvider.createTokensByLogin(memberDto);
         return ResponseEntity.ok(tokenList);
     }
 

--- a/src/test/java/com/example/rqs/api/jwt/JwtProviderImplTest.java
+++ b/src/test/java/com/example/rqs/api/jwt/JwtProviderImplTest.java
@@ -53,7 +53,7 @@ public class JwtProviderImplTest {
     @Test
     @DisplayName("jwtProvider 토큰 생성 테스트")
     void jwtCreateTokenTest() {
-        TokenResponse tokenList = jwtProviderImpl.createTokenList(new MemberDto(1L, "sol@sol.com", "sol", ""));
+        TokenResponse tokenList = jwtProviderImpl.createTokensByLogin(new MemberDto(1L, "sol@sol.com", "sol", ""));
         assertAll(
                 () -> assertThat(tokenList.getAtk()).isNotEmpty(),
                 () -> assertThat(tokenList.getRtk()).isNotEmpty()
@@ -63,7 +63,7 @@ public class JwtProviderImplTest {
     @Test
     @DisplayName("jwtProvider 토큰 Payload Subject 확인 테스트")
     void jwtPayloadSubjectTest() throws JsonProcessingException {
-        TokenResponse tokenList = jwtProviderImpl.createTokenList(new MemberDto(1L, "sol@sol.com", "sol", ""));
+        TokenResponse tokenList = jwtProviderImpl.createTokensByLogin(new MemberDto(1L, "sol@sol.com", "sol", ""));
         Subject subject = jwtProviderImpl.getSubject(tokenList.getAtk());
         assertAll(
                 () -> assertThat(subject.getEmail()).isEqualTo("sol@sol.com"),


### PR DESCRIPTION
#39 


## 해결 방법
- 기존 `Subject` 객체에 `type` 필드를 추가
- Security Filter 단계인 `JwtAuthenticationFilter`에서 token을 검증 및 payload를 꺼낸 뒤, 추가 검증을 진행한다.
- 추가 검증은 토큰의 `type`이 **RTK**라면, RequestURI가 `/api/v1/accout/reissue`인 경우에만 접근 허용하도록 한다.
- 즉, RTK는 재발급 API만 접근 가능하도록 수정

### 추가 자잘한 수정
- 기존에는 atk를 재발급하면서 rtk 또 한 재발급이 진행 되었으나, atk만 재발급하도록 수정
- 로그인을 통한 atk 및 rtk 토큰 발급 메서드 명 수정