### PR TITLE
Feature/#71 소셜 로그인 구현하기

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,5 @@
 sudo docker rm -f app
+sudo docker rmi quizbox/app
 sudo docker pull quizbox/app:latest
 sudo docker run --name app -d -p 8080:8080 --network quizbox quizbox/app:latest
 sudo docker image prune -f

--- a/src/main/java/com/example/rqs/api/config/ApiConfig.java
+++ b/src/main/java/com/example/rqs/api/config/ApiConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -62,5 +63,10 @@ public class ApiConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    @Bean
+    public RestTemplate getRestTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/java/com/example/rqs/api/config/ApiConfig.java
+++ b/src/main/java/com/example/rqs/api/config/ApiConfig.java
@@ -45,7 +45,7 @@ public class ApiConfig {
                 .antMatchers(
                         "/api/v1/member/info",
                         "/api/v1/space/**", "/api/v1/item/**",
-                        "/api/v1/member/sign-up", "/api/v1/member/login", "/api/v1/member/check").permitAll()
+                        "/api/v1/member/sign-up", "/api/v1/member/login", "/api/v1/member/oauth/**", "/api/v1/member/check").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, memberDetailsService),

--- a/src/main/java/com/example/rqs/api/jwt/JwtProvider.java
+++ b/src/main/java/com/example/rqs/api/jwt/JwtProvider.java
@@ -8,4 +8,5 @@ public interface JwtProvider {
     TokenResponse createTokensByLogin(MemberDto memberDto);
     String reissueAtk(MemberDto memberDto);
     Subject getSubject(String atk) throws JwtException, JsonProcessingException;
+    byte[] decode(String token);
 }

--- a/src/main/java/com/example/rqs/api/jwt/JwtProviderImpl.java
+++ b/src/main/java/com/example/rqs/api/jwt/JwtProviderImpl.java
@@ -73,6 +73,12 @@ public class JwtProviderImpl implements JwtProvider {
         return objectMapper.readValue(subjectStr, Subject.class);
     }
 
+    @Override
+    public byte[] decode(String token) {
+        String payload = token.split("\\.")[1];
+        return Base64.getDecoder().decode(payload);
+    }
+
     private String createToken(Subject subject, Long tokenLive) throws JsonProcessingException {
         String subjectStr = objectMapper.writeValueAsString(subject);
         Claims claims = Jwts.claims()

--- a/src/main/java/com/example/rqs/api/oauth/OauthManager.java
+++ b/src/main/java/com/example/rqs/api/oauth/OauthManager.java
@@ -1,0 +1,5 @@
+package com.example.rqs.api.oauth;
+
+public interface OauthManager {
+    OauthProfile verify(String token);
+}

--- a/src/main/java/com/example/rqs/api/oauth/OauthProfile.java
+++ b/src/main/java/com/example/rqs/api/oauth/OauthProfile.java
@@ -1,5 +1,6 @@
 package com.example.rqs.api.oauth;
 
+import com.example.rqs.core.member.service.dtos.OauthLoginDto;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -18,5 +19,9 @@ public class OauthProfile {
 
     public static OauthProfile of(String id, String nickname, String avatar) {
         return new OauthProfile(id, nickname, avatar);
+    }
+
+    public OauthLoginDto toOauthLoginDto(String type) {
+        return OauthLoginDto.of(id, nickname, avatar, type);
     }
 }

--- a/src/main/java/com/example/rqs/api/oauth/OauthProfile.java
+++ b/src/main/java/com/example/rqs/api/oauth/OauthProfile.java
@@ -1,0 +1,22 @@
+package com.example.rqs.api.oauth;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class OauthProfile {
+    private final String id;
+    private final String nickname;
+    private final String avatar;
+
+    private OauthProfile(String id, String nickname, String avatar) {
+        this.id = id;
+        this.nickname = nickname;
+        this.avatar = avatar;
+    }
+
+    public static OauthProfile of(String id, String nickname, String avatar) {
+        return new OauthProfile(id, nickname, avatar);
+    }
+}

--- a/src/main/java/com/example/rqs/api/oauth/OauthType.java
+++ b/src/main/java/com/example/rqs/api/oauth/OauthType.java
@@ -1,0 +1,26 @@
+package com.example.rqs.api.oauth;
+
+import com.example.rqs.core.common.exception.BadRequestException;
+
+import java.util.Arrays;
+
+public enum OauthType {
+    GOOGLE("google");
+
+    final String type;
+
+    OauthType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public static OauthType valueOfType(String type) {
+        return Arrays
+                .stream(OauthType.values()).filter((e) -> e.type.equals(type))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException("Not Supported Oauth Type"));
+    }
+}

--- a/src/main/java/com/example/rqs/api/oauth/OauthType.java
+++ b/src/main/java/com/example/rqs/api/oauth/OauthType.java
@@ -5,7 +5,8 @@ import com.example.rqs.core.common.exception.BadRequestException;
 import java.util.Arrays;
 
 public enum OauthType {
-    GOOGLE("google");
+    GOOGLE("google"),
+    KAKAO("kakao");
 
     final String type;
 

--- a/src/main/java/com/example/rqs/api/oauth/google/GoogleOauthAccess.java
+++ b/src/main/java/com/example/rqs/api/oauth/google/GoogleOauthAccess.java
@@ -1,0 +1,14 @@
+package com.example.rqs.api.oauth.google;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GoogleOauthAccess {
+    private String access_token;
+    private Long expires_in;
+    private String scope;
+    private String token_type;
+    private String id_token;
+}

--- a/src/main/java/com/example/rqs/api/oauth/google/GoogleOauthManager.java
+++ b/src/main/java/com/example/rqs/api/oauth/google/GoogleOauthManager.java
@@ -62,7 +62,8 @@ public class GoogleOauthManager implements OauthManager {
         byte[] decode = jwtProvider.decode(googleOauthAccess.getId_token());
         try {
             GoogleTokenPayload googleTokenPayload = objectMapper.readValue(decode, GoogleTokenPayload.class);
-            return OauthProfile.of(googleTokenPayload.getAzp(), googleTokenPayload.getName(), googleTokenPayload.getPicture());
+            System.out.println(googleTokenPayload.toString());
+            return OauthProfile.of(googleTokenPayload.getSub(), googleTokenPayload.getName(), googleTokenPayload.getPicture());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/example/rqs/api/oauth/google/GoogleOauthManager.java
+++ b/src/main/java/com/example/rqs/api/oauth/google/GoogleOauthManager.java
@@ -1,0 +1,70 @@
+package com.example.rqs.api.oauth.google;
+
+import com.example.rqs.api.jwt.JwtProvider;
+import com.example.rqs.api.oauth.OauthManager;
+import com.example.rqs.api.oauth.OauthProfile;
+import com.example.rqs.core.common.exception.BadRequestException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+
+@Service("googleOauth")
+@RequiredArgsConstructor
+public class GoogleOauthManager implements OauthManager {
+    @Value("${oauth.google.client-id}")
+    private String CLIENT_ID;
+    @Value("${oauth.google.client-secret}")
+    private String CLIENT_SECRET;
+    @Value("${oauth.google.redirect-uri}")
+    private String REDIRECT_URI;
+    @Value("${oauth.google.grant-type}")
+    private String GRANT_TYPE;
+
+    private final RestTemplate restTemplate;
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public OauthProfile verify(String token) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", token);
+        body.add("client_id", CLIENT_ID);
+        body.add("client_secret", CLIENT_SECRET);
+        body.add("redirect_uri", REDIRECT_URI);
+        body.add("grant_type", GRANT_TYPE);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        String url = "https://oauth2.googleapis.com/token";
+
+        try {
+            GoogleOauthAccess googleOauthAccess = restTemplate.postForObject(url, request, GoogleOauthAccess.class);
+            assert googleOauthAccess != null;
+            return generateOauthProfile(googleOauthAccess);
+        } catch (HttpClientErrorException e) {
+            throw new BadRequestException(e.getMessage());
+        }
+    }
+
+    private OauthProfile generateOauthProfile(GoogleOauthAccess googleOauthAccess) {
+        byte[] decode = jwtProvider.decode(googleOauthAccess.getId_token());
+        try {
+            GoogleTokenPayload googleTokenPayload = objectMapper.readValue(decode, GoogleTokenPayload.class);
+            return OauthProfile.of(googleTokenPayload.getAzp(), googleTokenPayload.getName(), googleTokenPayload.getPicture());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/example/rqs/api/oauth/google/GoogleTokenPayload.java
+++ b/src/main/java/com/example/rqs/api/oauth/google/GoogleTokenPayload.java
@@ -1,0 +1,23 @@
+package com.example.rqs.api.oauth.google;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class GoogleTokenPayload {
+    private String iss;
+    private String azp;
+    private String aud;
+    private String sub;
+    private String email;
+    private Boolean email_verified;
+    private String at_hash;
+    private String name;
+    private String picture;
+    private String locale;
+    private Long iat;
+    private Long exp;
+}

--- a/src/main/java/com/example/rqs/api/oauth/kakao/KakaoOauthAccess.java
+++ b/src/main/java/com/example/rqs/api/oauth/kakao/KakaoOauthAccess.java
@@ -1,0 +1,14 @@
+package com.example.rqs.api.oauth.kakao;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoOauthAccess {
+    private String access_token;
+    private String refresh_token;
+    private Long expires_in;
+    private String scope;
+    private Long refresh_token_expires_in;
+}

--- a/src/main/java/com/example/rqs/api/oauth/kakao/KakaoOauthManager.java
+++ b/src/main/java/com/example/rqs/api/oauth/kakao/KakaoOauthManager.java
@@ -1,0 +1,80 @@
+package com.example.rqs.api.oauth.kakao;
+
+import com.example.rqs.api.oauth.OauthManager;
+import com.example.rqs.api.oauth.OauthProfile;
+import com.example.rqs.core.common.exception.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+@Service("kakaoOauth")
+@RequiredArgsConstructor
+public class KakaoOauthManager implements OauthManager {
+    @Value("${oauth.kakao.client-id}")
+    private String CLIENT_ID;
+    @Value("${oauth.kakao.redirect-uri}")
+    private String REDIRECT_URI;
+    @Value("${oauth.kakao.grant-type}")
+    private String GRANT_TYPE;
+
+    private final RestTemplate restTemplate;
+
+    @Override
+    public OauthProfile verify(String token) {
+        KakaoOauthAccess oauthAccess = getOauthAccess(token);
+        KakaoProfile profile = getProfile(oauthAccess);
+        return generateOauthProfile(profile);
+    }
+
+    private KakaoOauthAccess getOauthAccess(String token) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", token);
+        body.add("client_id", CLIENT_ID);
+        body.add("grant_type", GRANT_TYPE);
+        body.add("redirect_uri", REDIRECT_URI);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        String url = "https://kauth.kakao.com/oauth/token";
+
+        try {
+            return restTemplate.postForObject(url, request, KakaoOauthAccess.class);
+        } catch (HttpClientErrorException e) {
+            throw new BadRequestException(e.getMessage());
+        }
+    }
+
+    private KakaoProfile getProfile(KakaoOauthAccess access) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.setBearerAuth(access.getAccess_token());
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        String url = "https://kapi.kakao.com/v2/user/me";
+
+        try {
+            return restTemplate.postForObject(url, request, KakaoProfile.class);
+        } catch (HttpClientErrorException e) {
+            throw new BadRequestException(e.getMessage());
+        }
+    }
+
+    private OauthProfile generateOauthProfile(KakaoProfile profile) {
+        return OauthProfile.of(
+                String.valueOf(profile.getId()),
+                profile.getProperties().getNickname(),
+                profile.getProperties().getProfile_image()
+        );
+    }
+}

--- a/src/main/java/com/example/rqs/api/oauth/kakao/KakaoProfile.java
+++ b/src/main/java/com/example/rqs/api/oauth/kakao/KakaoProfile.java
@@ -1,0 +1,12 @@
+package com.example.rqs.api.oauth.kakao;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoProfile {
+    private Long id;
+    private String connected_at;
+    private Properties properties;
+}

--- a/src/main/java/com/example/rqs/api/oauth/kakao/Properties.java
+++ b/src/main/java/com/example/rqs/api/oauth/kakao/Properties.java
@@ -1,0 +1,13 @@
+package com.example.rqs.api.oauth.kakao;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Properties {
+    private String nickname;
+    private String profile_image;
+    private String thumbnail_image;
+
+}

--- a/src/main/java/com/example/rqs/core/member/Member.java
+++ b/src/main/java/com/example/rqs/core/member/Member.java
@@ -28,16 +28,21 @@ public class Member {
 
     protected Member() {}
 
-    private Member(String email, String password, String nickname) {
+    private Member(String email, String password, String nickname, String avatar) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
+        this.avatar = avatar;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }
 
     public static Member newMember(String email, String password, String nickname) {
-        return new Member(email, password, nickname);
+        return new Member(email, password, nickname, "");
+    }
+
+    public static Member newMember(String email, String password, String nickname, String avatar) {
+        return new Member(email, password, nickname, avatar);
     }
 
     public void updateNickname(String nickname) {

--- a/src/main/java/com/example/rqs/core/member/service/MemberAuthService.java
+++ b/src/main/java/com/example/rqs/core/member/service/MemberAuthService.java
@@ -3,11 +3,13 @@ package com.example.rqs.core.member.service;
 import com.example.rqs.core.member.Member;
 import com.example.rqs.core.member.service.dtos.LoginDto;
 import com.example.rqs.core.member.service.dtos.MemberDto;
+import com.example.rqs.core.member.service.dtos.OauthLoginDto;
 
 import java.util.Optional;
 
 public interface MemberAuthService {
     MemberDto login(LoginDto loginDto);
+    MemberDto oauthLogin(OauthLoginDto oauthLoginDto);
     boolean logout();
     boolean existEmail(String email);
     Optional<Member> getMember(long memberId);

--- a/src/main/java/com/example/rqs/core/member/service/MemberAuthServiceImpl.java
+++ b/src/main/java/com/example/rqs/core/member/service/MemberAuthServiceImpl.java
@@ -34,6 +34,7 @@ public class MemberAuthServiceImpl implements MemberAuthService {
     }
 
     @Override
+    @Transactional
     public MemberDto oauthLogin(OauthLoginDto oauthLoginDto) {
         String email = oauthLoginDto.getId() + "@" + oauthLoginDto.getType() + ".quizbox";
         Optional<Member> optionalMember = memberRepository.findByEmail(email);

--- a/src/main/java/com/example/rqs/core/member/service/MemberAuthServiceImpl.java
+++ b/src/main/java/com/example/rqs/core/member/service/MemberAuthServiceImpl.java
@@ -6,6 +6,7 @@ import com.example.rqs.core.member.Member;
 import com.example.rqs.core.member.repository.MemberRepository;
 import com.example.rqs.core.member.service.dtos.LoginDto;
 import com.example.rqs.core.member.service.dtos.MemberDto;
+import com.example.rqs.core.member.service.dtos.OauthLoginDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberAuthServiceImpl implements MemberAuthService {
+    private final MemberRegisterService memberRegisterService;
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
@@ -29,6 +31,17 @@ public class MemberAuthServiceImpl implements MemberAuthService {
         boolean matches = passwordEncoder.matches(loginDto.getPassword(), member.getPassword());
         if (!matches) throw new BadRequestException(RQSError.INVALID_EMAIL_OR_PW);
         return MemberDto.of(member);
+    }
+
+    @Override
+    public MemberDto oauthLogin(OauthLoginDto oauthLoginDto) {
+        String email = oauthLoginDto.getId() + "@" + oauthLoginDto.getType() + ".quizbox";
+        Optional<Member> optionalMember = memberRepository.findByEmail(email);
+        if (optionalMember.isPresent()) {
+            return MemberDto.of(optionalMember.get());
+        }
+
+        return memberRegisterService.oauthSignUp(oauthLoginDto);
     }
 
     @Override

--- a/src/main/java/com/example/rqs/core/member/service/MemberRegisterService.java
+++ b/src/main/java/com/example/rqs/core/member/service/MemberRegisterService.java
@@ -1,8 +1,10 @@
 package com.example.rqs.core.member.service;
 
 import com.example.rqs.core.member.service.dtos.MemberDto;
+import com.example.rqs.core.member.service.dtos.OauthLoginDto;
 import com.example.rqs.core.member.service.dtos.SignUpDto;
 
 public interface MemberRegisterService {
     MemberDto signUp(SignUpDto signUpDto);
+    MemberDto oauthSignUp(OauthLoginDto oauthLoginDto);
 }

--- a/src/main/java/com/example/rqs/core/member/service/MemberRegisterServiceImpl.java
+++ b/src/main/java/com/example/rqs/core/member/service/MemberRegisterServiceImpl.java
@@ -5,22 +5,24 @@ import com.example.rqs.core.common.exception.RQSError;
 import com.example.rqs.core.member.Member;
 import com.example.rqs.core.member.repository.MemberRepository;
 import com.example.rqs.core.member.service.dtos.MemberDto;
+import com.example.rqs.core.member.service.dtos.OauthLoginDto;
 import com.example.rqs.core.member.service.dtos.SignUpDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class MemberRegisterServiceImpl implements MemberRegisterService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Override
-    @Transactional
     public MemberDto signUp(SignUpDto signUpDto) {
         boolean exist = memberRepository.existsByEmail(signUpDto.getEmail());
         if (exist) throw new BadRequestException(RQSError.DUPLICATE_EMAIL);
@@ -28,5 +30,19 @@ public class MemberRegisterServiceImpl implements MemberRegisterService {
         Member member = Member.newMember(signUpDto.getEmail(), encodedPassword, signUpDto.getNickname());
         memberRepository.save(member);
         return MemberDto.of(member);
+    }
+
+    @Override
+    public MemberDto oauthSignUp(OauthLoginDto oauthLoginDto) {
+        String email = oauthLoginDto.getId() + "@" + oauthLoginDto.getType() + ".quizbox";
+        String password = generateOauthPassword(oauthLoginDto);
+        Member member = Member.newMember(email, password, oauthLoginDto.getNickname(), oauthLoginDto.getAvatar());
+        memberRepository.save(member);
+        return MemberDto.of(member);
+    }
+
+    private String generateOauthPassword(OauthLoginDto oauthLoginDto) {
+        String password = oauthLoginDto.getId() + UUID.randomUUID() + oauthLoginDto.getType();
+        return passwordEncoder.encode(password);
     }
 }

--- a/src/main/java/com/example/rqs/core/member/service/dtos/OauthLoginDto.java
+++ b/src/main/java/com/example/rqs/core/member/service/dtos/OauthLoginDto.java
@@ -1,0 +1,22 @@
+package com.example.rqs.core.member.service.dtos;
+
+import lombok.Getter;
+
+@Getter
+public class OauthLoginDto {
+    private final String id;
+    private final String nickname;
+    private final String avatar;
+    private final String type;
+
+    private OauthLoginDto(String id, String nickname, String avatar, String type) {
+        this.id = id;
+        this.nickname = nickname;
+        this.avatar = avatar;
+        this.type = type;
+    }
+
+    public static OauthLoginDto of(String id, String nickname, String avatar, String type) {
+        return new OauthLoginDto(id, nickname, avatar, type);
+    }
+}

--- a/src/test/java/com/example/rqs/api/member/MemberControllerTest.java
+++ b/src/test/java/com/example/rqs/api/member/MemberControllerTest.java
@@ -115,7 +115,7 @@ public class MemberControllerTest {
         String req = objectMapper.writeValueAsString(updateMember);
 
         ResultActions perform = mockMvc.perform(
-                patch("/api/v1/member/nickname")
+                patch("/api/v1/member")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(req)
                         .with(csrf())

--- a/src/test/java/com/example/rqs/core/member/MemberUpdateServiceTest.java
+++ b/src/test/java/com/example/rqs/core/member/MemberUpdateServiceTest.java
@@ -23,20 +23,6 @@ public class MemberUpdateServiceTest {
     MemberRepository memberRepository;
 
     @Test
-    @DisplayName("멤버 nickname 업데이트 테스트")
-    void updateNicknameTest() {
-        // given
-        Member member = Member.newMember("sol@sol.com", "1234", "sol");
-        String newNickname = "solsol";
-
-        // when
-        MemberDto memberDto = memberUpdateService.updateNickname(member, newNickname);
-
-        // then
-        assertThat(memberDto.getNickname()).isEqualTo(newNickname);
-    }
-
-    @Test
     @DisplayName("멤버 avatar 업데이트 테스트")
     void updateAvatarTest() {
         // given
@@ -50,17 +36,17 @@ public class MemberUpdateServiceTest {
         assertThat(memberDto.getAvatar()).isEqualTo(avatarUrl);
     }
 
-    @Test
-    @DisplayName("멤버 description 업데이트 테스트")
-    void updateDescriptionTest() {
-        // given
-        Member member = Member.newMember("sol@sol.com", "1234", "sol");
-        String newDescription = "Hello, ";
-
-        // when
-        MemberDto memberDto = memberUpdateService.updateDescription(member, newDescription);
-
-        // then
-        assertThat(memberDto.getDescription()).isEqualTo(newDescription);
-    }
+//    @Test
+//    @DisplayName("멤버 description 업데이트 테스트")
+//    void updateDescriptionTest() {
+//        // given
+//        Member member = Member.newMember("sol@sol.com", "1234", "sol");
+//        String newDescription = "Hello, ";
+//
+//        // when
+//        MemberDto memberDto = memberUpdateService.updateDescription(member, newDescription);
+//
+//        // then
+//        assertThat(memberDto.getDescription()).isEqualTo(newDescription);
+//    }
 }


### PR DESCRIPTION
# 소셜 로그인 구현하기

- Google 및 kakao 로그인 제공
- 프론트에서 1차 id token 발급 후, 백엔드에서 인증 토큰 및 프로필 정보 조회
- 회원인 경우에는 로그인 처리, 아닌 경우에는 회원가입 처리 진행

## 공통 기능 인터페이스 활용
다음의 구조로 구성
```
- OauthManager
- OauthProfile
- OauthType
-- google
--- GoogleOauthManager
--- GoogleOauthAccess
--- GoogleTokenPayload
-- kakao
--- KakaoOauthManager
--- KakaoOauthAccess
--- KakaoProfile
```

- OauthManager가 공통의 `verify`메서드를 정의
- kakao 및 google은 위 인터페이스를 구현
- 플랫폼마다 인증 플로우가 다르기에 세부 구조는 각자 상세 구현
- 최종적으로 `OauthProfile`를 반환하도록 구성


### 추가 변경 예정
- 현재는 미회원인 경우 즉시 회원가입 및 로그인 처리를 진행
- 사용자에게 닉네임 및 간단 소개를 전달받아 최종 회원가입 처리를 하는 방식으로 변경될 수 있음.
