### PR TITLE
Feature/#81 로그인 & 미로그인 통합 처리 API에 대한 공통 로직 처리 인터셉터 구현

### DIFF
--- a/src/main/java/com/example/rqs/api/common/CommonAPI.java
+++ b/src/main/java/com/example/rqs/api/common/CommonAPI.java
@@ -1,0 +1,11 @@
+package com.example.rqs.api.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CommonAPI {
+}

--- a/src/main/java/com/example/rqs/api/common/CommonAPIInterceptor.java
+++ b/src/main/java/com/example/rqs/api/common/CommonAPIInterceptor.java
@@ -1,0 +1,43 @@
+package com.example.rqs.api.common;
+
+import com.example.rqs.api.jwt.MemberDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@RequiredArgsConstructor
+public class CommonAPIInterceptor implements HandlerInterceptor {
+    private final CommonAPIAuthChecker commonAPIAuthChecker;
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler
+    ) {
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+        if (!hasAnnotation(handlerMethod)) {
+            return true;
+        }
+
+        MemberDetails memberDetails = commonAPIAuthChecker.checkIsAuth(request.getHeader("Authorization"));
+        if (memberDetails == null) {
+            return true;
+        }
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(memberDetails, "", memberDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        return true;
+    }
+
+    private boolean hasAnnotation(HandlerMethod handlerMethod) {
+        CommonAPI commonAPI = handlerMethod.getMethodAnnotation(CommonAPI.class);
+        return commonAPI == null;
+    }
+}


### PR DESCRIPTION
#  로그인 & 미로그인 통합 처리 API에 대한 공통 로직 처리 인터셉터 구현

## 작업 내용

### CommonAPI 어노테이션
로그인 & 미로그인 공통 처리 API에 대한 인터셉터 적용을 위해 커스텀 어노테이션 작성

### CommonAPIInterceptor 구현
- `CommonAPI` 어노테이션이 적용 된 메서드만 처리되도록 분기 처리
- 헤더에서 `atk`를 꺼내어 `CommonAPIAuthChecker`를 통해 로그인 여부 확인
- 로그인 상태인 경우 `Security Context Holder`에 유저 정보 세팅